### PR TITLE
Clear old Authorization header before retry

### DIFF
--- a/angular-http-auth.js
+++ b/angular-http-auth.js
@@ -197,6 +197,7 @@ angular.module('ur.http.auth', []).service("base64", ['$window', function($windo
 		$get: ['$http', function($http) {
 
 			function retry(request) {
+        delete(request.config.headers['Authorization']);
 				$http(request.config).then(function(response) {
 					request.deferred.resolve(response);
 				});


### PR DESCRIPTION
I have found that queued failed requests retain the Authorization header that was originally sent with them. As a consequence a user can never successfully re-enter credentials because failed requests persist in failing. Removing the Authorization header from requests before retrying them seems to work.
