### PR TITLE
Fix queued requests not taking updated credentials

### DIFF
--- a/angular-http-auth.js
+++ b/angular-http-auth.js
@@ -197,6 +197,10 @@ angular.module('ur.http.auth', []).service("base64", ['$window', function($windo
 		$get: ['$http', function($http) {
 
 			function retry(request) {
+				var defaultHeaders = $http.defaults.headers[request.config.method] || 
+          $http.defaults.headers.common;
+          
+        angular.extend(request.config.headers, defaultHeaders);
 				$http(request.config).then(function(response) {
 					request.deferred.resolve(response);
 				});


### PR DESCRIPTION
Queued requests are re-sent in a way that `$http.default.headers` are ignored, which causes updated credentials never been picked up.

The fix extends the header of a queued request with the latest `$http.default.headers` before retrying so that custom headers in the original request (if applicable) will be retained and the latest auth headers attached.

This fixes #5.
