### PR TITLE
Use revised interceptors API

### DIFF
--- a/src/angular-http-auth.js
+++ b/src/angular-http-auth.js
@@ -196,13 +196,11 @@ angular.module('ur.http.auth', []).service("base64", ['$window', function($windo
     },
 
     subscribeTo: function($httpProvider) {
-      $httpProvider.responseInterceptors.push(['$q', function($q) {
-        return function (promise) {
-          return promise.then(function success(resp) {
-            return resp;
-          }, function error(resp) {
+      $httpProvider.interceptors.push(['$q', function($q) {
+        return {
+          responseError: function(resp) {
             return isValid(resp) ? enqueueAndNotify(resp, $q.defer()) : $q.reject(resp);
-          });
+          }
         };
       }]);
     },


### PR DESCRIPTION
This API became available in 1.1.4, and was removed in 1.3 (see
https://github.com/angular/angular.js/commit/ad4336f9359a073e272930f8f9bcd36587a8648f)